### PR TITLE
AttachmentProperty features

### DIFF
--- a/pykechain/models/attachment.py
+++ b/pykechain/models/attachment.py
@@ -26,6 +26,15 @@ class AttachmentProperty(Property):
         except ImportError:
             pass
 
+    def upload(self, filename):
+        """Upload a file to the attachment property.
+
+        :param filename: File path
+        :raises: APIError
+        """
+        with open(filename, 'rb') as f:
+            self._upload(f)
+
     def save_as(self, filename):
         """Download the attachment to a file.
 


### PR DESCRIPTION
Right now the attachment property has the following functions:

```
property.value = matplotlib.figure  # upload figure (plot) to KE-chain
property.upload('test.csv')   # upload a local file called test.csv to KE-chain
property.save_as('something.txt')  # download the file from KE-chain to a local file 
```

There is not yet clear functionality to handle json formats, although a lot is possible out of the box with requests.

@jberends what features are required and do you want to say something related to unifying the attachment property API?