### PR TITLE
#435 numeric range validators

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,10 @@ Change Log
 
 pykechain changelog
 
+2.5.3 (18JAN19)
+---------------
+ * Fixed a bug where a numeric range validator from a property was not correctly instantiated for provided min/max values when the validator was retrieved from the KE-chain backend. Thanks to @bastiaanbeijer for finding this! (#435)
+
 2.5.2 (30NOV18)
 ---------------
  * Fixed the customizations to be compatible with KE-chain 3: `Custom Title` replaced by `Custom title`; added the possibility to include the `Clone button` where applicable. The `metaWidget` now uses 'Set height' and 'Automatic height'. (#421) thanks to @raduiordache.

--- a/pykechain/__about__.py
+++ b/pykechain/__about__.py
@@ -2,7 +2,7 @@
 name = 'pykechain'
 description = 'KE-chain Python SDK'
 
-version = '2.5.2'
+version = '3.0.0-rc1'
 
 author = 'KE-works BV'
 email = 'support+pykechain@ke-works.com'

--- a/pykechain/__about__.py
+++ b/pykechain/__about__.py
@@ -2,7 +2,7 @@
 name = 'pykechain'
 description = 'KE-chain Python SDK'
 
-version = '3.0.0-rc1'
+version = '2.5.3'
 
 author = 'KE-works BV'
 email = 'support+pykechain@ke-works.com'

--- a/pykechain/models/validators/validators.py
+++ b/pykechain/models/validators/validators.py
@@ -64,8 +64,16 @@ class NumericRangeValidator(PropertyValidator):
         if enforce_stepsize is not None:
             self._config['enforce_stepsize'] = enforce_stepsize
 
-        self.minvalue = float('-inf') if minvalue is None else minvalue
-        self.maxvalue = float('inf') if maxvalue is None else maxvalue
+        if self._config.get('minvalue') is None:
+            self.minvalue = float('-inf')
+        else:
+            self.minvalue = self._config.get('minvalue')
+        if self._config.get('maxvalue') is None:
+            self.maxvalue = float('inf')
+        else:
+            self.maxvalue = self._config.get('maxvalue')
+        # self.minvalue = float('-inf') if self._config.get('minvalue') is None else self._config.get('minvalue')
+        # self.maxvalue = float('inf') if self._config.get('maxvalue') is None else self._config.get('maxvalue')
         self.stepsize = self._config.get('stepsize', None)
         self.enforce_stepsize = self._config.get('enforce_stepsize', None)
 

--- a/tests/classes.py
+++ b/tests/classes.py
@@ -19,11 +19,16 @@ with Betamax.configure() as config:
 
 class SixTestCase(TestCase):
     def assertRaisesRegex(self, expected_exception, expected_regex, *args, **kwargs):
-
         if six.PY2:
             return self.assertRaisesRegexp(expected_exception, expected_regex, *args, **kwargs)
         else:
             return super(__class__, self).assertRaisesRegex(expected_exception, expected_regex, *args, **kwargs)
+
+    def assertRegex(self, text, expected_regex, *args, **kwargs):
+        if six.PY2:
+            return self.assertRegexpMatches(text, expected_regex, *args, **kwargs)
+        else:
+            return super(__class__, self).assertRegex(text, expected_regex, *args, **kwargs)
 
 class TestBetamax(SixTestCase):
     @property

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -280,6 +280,17 @@ class TestNumericRangeValidator(SixTestCase):
         with self.assertRaisesRegex(Exception, 'The stepsize should be provided when enforcing stepsize'):
             NumericRangeValidator(stepsize=None, enforce_stepsize=True)
 
+    def test_numeric_range_does_not_respect_max_issue_435(self):
+        """With reference to issue #435
+
+        In KE-chain I've added a property with numeric range validators min = unbound and max = 1000.
+        A value of 3333 simply returns as valid in pykechain:
+        _validation_reasons =>'Value \'3333\' is between -inf and inf'
+        """
+        validator = NumericRangeValidator(maxvalue=1000)
+        self.assertFalse(validator.is_valid(3333))
+        self.assertRegex(validator.get_reason(), "Value '3333' should be between -inf and 1000")
+
 
 class TestBooleanFieldValidator(SixTestCase):
     def test_boolean_validator_without_settings(self):
@@ -486,6 +497,24 @@ class TestPropertyWithValidator(SixTestCase):
 
     def test_property_with_boolean_validator(self):
         pass
+
+    def test_property_with_numericrangevalidator(self):
+        prop_json = dict(
+            value=None,
+            options=dict(
+                validators=[{'vtype': 'numericRangeValidator', 'config': {'maxvalue': 1000, 'minvalue': 0}},
+                                {'vtype': 'requiredFieldValidator', 'config': {}}]
+            ))
+        prop = Property(json=prop_json, client=None)
+        self.assertEqual(len(prop.validators), 2)
+        validators = prop.validators
+        numrange_validator = validators[0]
+        req_validator = validators[1]
+        self.assertIsInstance(numrange_validator, NumericRangeValidator)
+        self.assertIsInstance(req_validator, RequiredFieldValidator)
+        self.assertFalse(numrange_validator(2222))
+
+
 
 class TestPropertyWithValidatorFromLiveServer(TestBetamax):
 


### PR DESCRIPTION
* updated the numeric range validator parsing.
* ensuring that provided maxvalue in the config is injected correctly as max/minvalue of the validator.