### PR TITLE
Cached children bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+v3.8.2-rc2
+----------
+
+* :bug: The `descendants` of a `Part` with classification `CATALOG` returns both the Catalog and Product descendants. This broke the guaranteed parent-child relationship when populating the descendants in the `populate_descendants()` method of the `Part` class.
+
 v3.8.1 (08SEP20)
 ----------------
 

--- a/pykechain/__about__.py
+++ b/pykechain/__about__.py
@@ -2,7 +2,7 @@
 name = 'pykechain'
 description = 'KE-chain Python SDK'
 
-version = '3.8.1'
+version = '3.8.2-rc2'
 
 author = 'KE-works BV'
 email = 'support+pykechain@ke-works.com'

--- a/pykechain/models/tree_traversal.py
+++ b/pykechain/models/tree_traversal.py
@@ -117,7 +117,7 @@ class TreeObject(BaseInScope, ABC):
         # Populate every descendant with its parent
         object_by_id = {c.id: c for c in all_descendants + [self]}
         for descendant in all_descendants:
-            descendant._parent = object_by_id[descendant.parent_id]
+            descendant._parent = object_by_id.get(descendant.parent_id)
 
         this_children = children_by_parent_id.get(self.id, list())
         if self._cached_children and not overwrite:


### PR DESCRIPTION
Descendants of a CATALOG part return PRODUCT parts

Fixes #<issue>

## Checklist:
- [x] My code follows the pykechain style
    - [ ] I added type hinting to all functions
    - [ ] I added documentation for all public functions
    - [ ] I locally used `tox` to check for dists and docs errors
    - [ ] My code passes the `pep8` and `flake8` linting checks and no warnings
    - [ ] I removed unused imports, using `Code > Optimize Imports` in PyCharm
    - [ ] I used [`black`](https://github.com/psf/black) to format the new code
- [ ] I have added tests that prove my fix is effective or that my feature works
    - [ ] I committed fresh test cassettes
    - [ ] I have proper test coverage (don't decline the coverage of the test)
- [ ] I asked another teammate to review the code
- [x] I update the Changelog.md with the appropriate changes.
