### PR TITLE
empty value in activity edit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ v3.9.1 (27NOV20)
 * :bug: In the `Part.property()` method, the property is retrieved by matching a `name` prior to matching a `ref`, to prevent conflicts when these might identical between different properties.
 * :bug: The `text` and `is_active` inputs for editing of a `Banner` were not properly managed, leading to API errors or unchanged values.
 * :bug: Batched property values of `BaseReference` and inherited classes are now stored as lists of dicts instead of list of UUIDs, to simulate values retrieved directly from KE-chain.
+* :bug: Resolved small issue where `empty` values were being combined with normal objects in the `edit_cascade_down()` method of the `Activity` class.
 
 * :+1: Refactored a lot of the strings used in the `Widget` meta into enums, to help with consistency.
 * :+1: Retrieving the `value` of any reference property is now performed in batches to limit request size, using the existing `get_in_chunks` utility function.

--- a/pykechain/models/activity.py
+++ b/pykechain/models/activity.py
@@ -629,7 +629,6 @@ class Activity(TreeObject, TagsMixin, Activity2):
 
         # If both are empty that means the user is not interested in changing them
         if isinstance(assignees_ids, Empty) and isinstance(assignees, Empty):
-            update_dict['assignees_ids'] = empty
             return update_dict
         # If one of them is None, then the assignees will be cleared from the Activity
         elif assignees is None or assignees_ids is None:

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -514,7 +514,9 @@ class TestActivities(TestBetamax):
         testuser = self.client.user(username="testuser")
 
         subprocess.edit_cascade_down(
-            assignees=["testuser"], status=ActivityStatus.COMPLETED, overwrite=False,
+            assignees=["testuser"],
+            status=ActivityStatus.COMPLETED,
+            overwrite=False,
         )
 
         subprocess.refresh()


### PR DESCRIPTION
Resolved small issue where `empty` values were being combined with a list in the `edit_cascade_down()` method of the `Activity` class.

Fixes #<issue>

## Checklist:
- [x] My code follows the pykechain style
    - [x] I added type hinting to all functions
    - [x] I added documentation for all public functions
    - [x] I locally used `tox` to check for dists and docs errors
    - [x] My code passes the `pep8` and `flake8` linting checks and no warnings
    - [x] I removed unused imports, using `Code > Optimize Imports` in PyCharm
    - [x] I used [`black`](https://github.com/psf/black) to format the new code
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] I committed fresh test cassettes
    - [x] I have proper test coverage (don't decline the coverage of the test)
- [x] I asked another teammate to review the code
- [x] I update the Changelog.md with the appropriate changes.
