### PR TITLE
Deprecation of python 3.5 due to lack of f-strings

### DIFF
--- a/.github/workflows/python_testing.yml
+++ b/.github/workflows/python_testing.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 6
       fail-fast: False
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
 
     steps:
     - uses: actions/checkout@v1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ UNRELEASED
 * :bug: Fixed a test_cassette that was failing on a date check. Made it use a fixed date rather than doing it on today.
 * :bug: Fixed automatic compilation of the pykechain documentation on https://readthedocs.org/projects/pykechain/.
 
+* :+1: From now on python 3.5 is deprecated. We can now start to insert f-strings in our pykechain codebase.
+
 v3.11.1 (15JUN21)
 -----------------
 * :bug: Fixed an issue related to setting prefilters on a `ScopeReferenceProperty`.

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -14,3 +14,7 @@ class TestAbout(TestCase):
         self.assertTrue(about.version)
         import semver
         self.assertTrue(semver.VersionInfo.parse(about.version))
+
+    def test_python_fstring(self):
+        true = f"this is {True}"
+        self.assertEqual(f"{true}", true)

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@ commands =
     python setup.py test
 
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8


### PR DESCRIPTION
Fixes #<issue>

## Checklist:
- [X] My code follows the pykechain style
    - [X] I added type hinting to all functions
    - [X] I added documentation for all public functions
    - [X] I locally used `tox` to check for dists and docs errors
    - [X] My code passes the `pep8` and `flake8` linting checks and no warnings
    - [X] I removed unused imports, using `Code > Optimize Imports` in PyCharm
    - [X] I used [`black`](https://github.com/psf/black) to format the new code
- [X] I have added tests that prove my fix is effective or that my feature works
    - [X] I committed fresh test cassettes
    - [X ] I have proper test coverage (don't decline the coverage of the test)
- [X] I asked another teammate to review the code
- [X] I update the Changelog.md with the appropriate changes.
