### PR TITLE
KE-1052 Implement custom Retry class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ UNRELEASED
 * :bug: Fixed a test_cassette that was failing on a date check. Made it use a fixed date rather than doing it on today.
 * :bug: Fixed automatic compilation of the pykechain documentation on https://readthedocs.org/projects/pykechain/.
 
+* :+1: When connecting to a server with a self-signed certificate which cannot be checked, we provide a message fast. (KE-1052, #997)
+
 v3.11.1 (15JUN21)
 -----------------
 * :bug: Fixed an issue related to setting prefilters on a `ScopeReferenceProperty`.

--- a/pykechain/client.py
+++ b/pykechain/client.py
@@ -32,7 +32,7 @@ from .models.input_checks import check_datetime, check_list_of_text, check_text,
 from .models.banner import Banner
 
 
-class KERetry(Retry):
+class PykeRetry(Retry):
     def increment(
         self,
         method=None,
@@ -117,11 +117,11 @@ class Client(object):
 
         # Retry implementation
         adapter = HTTPAdapter(
-            max_retries=KERetry(total=RETRY_TOTAL,
-                              connect=RETRY_ON_CONNECTION_ERRORS,
-                              read=RETRY_ON_READ_ERRORS,
-                              redirect=RETRY_ON_REDIRECT_ERRORS,
-                              backoff_factor=RETRY_BACKOFF_FACTOR)
+            max_retries=PykeRetry(total=RETRY_TOTAL,
+                                  connect=RETRY_ON_CONNECTION_ERRORS,
+                                  read=RETRY_ON_READ_ERRORS,
+                                  redirect=RETRY_ON_REDIRECT_ERRORS,
+                                  backoff_factor=RETRY_BACKOFF_FACTOR)
         )
         self.session.mount('https://', adapter=adapter)
         self.session.mount('http://', adapter=adapter)

--- a/pykechain/client_utils.py
+++ b/pykechain/client_utils.py
@@ -1,0 +1,34 @@
+from ssl import SSLCertVerificationError
+
+from urllib3 import Retry
+from urllib3.exceptions import MaxRetryError
+
+
+class PykeRetry(Retry):
+    def increment(
+        self,
+        method=None,
+        url=None,
+        response=None,
+        error=None,
+        _pool=None,
+        _stacktrace=None,
+    ):
+        """
+        In case of failed verification of self signed certificate we short circuit the retry routine.
+        """
+        if self._is_self_signed_certificate_error(error):
+            raise MaxRetryError(_pool, url, error)
+
+        return super().increment(
+            method=method,
+            url=url,
+            response=response,
+            error=error,
+            _pool=_pool,
+            _stacktrace=_stacktrace,
+        )
+
+    def _is_self_signed_certificate_error(self, error):
+        error_msg = "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate"
+        return error and isinstance(error, SSLCertVerificationError) and error_msg in str(error)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,8 +1,8 @@
 from ssl import SSLCertVerificationError
 from unittest import TestCase
 
-from client import PykeRetry
-from defaults import (
+from pykechain.client_utils import PykeRetry
+from pykechain.defaults import (
     RETRY_BACKOFF_FACTOR,
     RETRY_ON_CONNECTION_ERRORS,
     RETRY_ON_READ_ERRORS,

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,31 @@
+from ssl import SSLCertVerificationError
+from unittest import TestCase
+
+from client import PykeRetry
+from defaults import (
+    RETRY_BACKOFF_FACTOR,
+    RETRY_ON_CONNECTION_ERRORS,
+    RETRY_ON_READ_ERRORS,
+    RETRY_ON_REDIRECT_ERRORS,
+    RETRY_TOTAL
+)
+from urllib3.exceptions import MaxRetryError
+
+
+class TestPykeRetry(TestCase):
+    def test_short_circuit_on_self_signed_cert_error(self):
+        """Retry should return early if self signed cert verification fails"""
+        retry = PykeRetry(
+            total=RETRY_TOTAL,
+            connect=RETRY_ON_CONNECTION_ERRORS,
+            read=RETRY_ON_READ_ERRORS,
+            redirect=RETRY_ON_REDIRECT_ERRORS,
+            backoff_factor=RETRY_BACKOFF_FACTOR,
+        )
+
+        with self.assertRaises(MaxRetryError):
+            retry.increment(
+                error=SSLCertVerificationError(
+                    "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate"
+                )
+            )


### PR DESCRIPTION
Preventing self signed certificate exceptions from retrying and exiting early instead.

Fixes #<issue>

## Checklist:
- [x] My code follows the pykechain style
    - [x] I added type hinting to all functions
    - [x] I added documentation for all public functions
    - [x] I locally used `tox` to check for dists and docs errors
    - [x] My code passes the `pep8` and `flake8` linting checks and no warnings
    - [x] I removed unused imports, using `Code > Optimize Imports` in PyCharm
    - [x] I used [`black`](https://github.com/psf/black) to format the new code
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] I committed fresh test cassettes
    - [x] I have proper test coverage (don't decline the coverage of the test)
- [x] I asked another teammate to review the code
- [x] I update the Changelog.md with the appropriate changes.
