### PR TITLE
runned the `com2ann` conversion to change the type comments to type a…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,8 @@ UNRELEASED
 * :+1: From now on python 3.5 is deprecated. We can now start to insert f-strings in our pykechain codebase.
 * :+1: refactoring all models that were shadowed with a `<classname>2` to enable fast and smooth deprecation in July 2021.
 
-* :+1: When connecting to a server with a self-signed certificate which cannot be checked, we provide a message fast. (KE-1052, #997)
+* :+1: When connecting to a server with a SSL certificate error which cannot be checked, we provide a message fast and dont retry. (KE-1052, #997)
+* :+1: We converted all type annotations in comments to proper type and variable annotations.
 
 v3.11.1 (15JUN21)
 -----------------

--- a/pykechain/client.py
+++ b/pykechain/client.py
@@ -50,7 +50,6 @@ from pykechain.models.team import Team
 from pykechain.models.user import User
 from pykechain.models.widgets.widget import Widget
 from pykechain.utils import find, get_in_chunks, is_uuid, is_valid_email, slugify_ref
-
 from .__about__ import version as pykechain_version
 from .client_utils import PykeRetry
 from .models.banner import Banner
@@ -99,8 +98,9 @@ class Client(object):
 
         """
         self.auth: Optional[Tuple[str, str]] = None
-        self.headers: Dict[str, str] = {'X-Requested-With': 'XMLHttpRequest',
-                        'PyKechain-Version': pykechain_version}
+        self.headers: Dict[str, str] = {
+            'X-Requested-With': 'XMLHttpRequest', 'PyKechain-Version': pykechain_version
+        }
         self.session: requests.Session = requests.Session()
 
         parsed_url = urlparse(url)
@@ -109,7 +109,7 @@ class Client(object):
 
         self.api_root = url
         self.headers: Dict[Text, Text] = {'X-Requested-With': 'XMLHttpRequest',
-                        'PyKechain-Version': pykechain_version}
+                                          'PyKechain-Version': pykechain_version}
         self.auth: Optional[Tuple[Text, Text]] = None
         self.last_request: Optional[requests.PreparedRequest] = None
         self.last_response: Optional[requests.Response] = None
@@ -1181,20 +1181,20 @@ class Client(object):
         return new_activity
 
     def clone_activities(
-        self,
-        activities: List[Union[Activity, Text]],
-        activity_parent: Union[Activity, Text],
-        activity_update_dicts: Optional[Dict] = None,
-        include_part_models: Optional[bool] = False,
-        include_part_instances: Optional[bool] = False,
-        include_children: Optional[bool] = True,
-        excluded_parts: Optional[List[Text]] = None,
-        part_parent_model: Optional[Union[Part, Text]] = None,
-        part_parent_instance: Optional[Union[Part, Text]] = None,
-        part_model_rename_template: Optional[Text] = None,
-        part_instance_rename_template: Optional[Text] = None,
-        asynchronous: Optional[bool] = False,
-        **kwargs
+            self,
+            activities: List[Union[Activity, Text]],
+            activity_parent: Union[Activity, Text],
+            activity_update_dicts: Optional[Dict] = None,
+            include_part_models: Optional[bool] = False,
+            include_part_instances: Optional[bool] = False,
+            include_children: Optional[bool] = True,
+            excluded_parts: Optional[List[Text]] = None,
+            part_parent_model: Optional[Union[Part, Text]] = None,
+            part_parent_instance: Optional[Union[Part, Text]] = None,
+            part_model_rename_template: Optional[Text] = None,
+            part_instance_rename_template: Optional[Text] = None,
+            asynchronous: Optional[bool] = False,
+            **kwargs
     ) -> List[Activity]:
         """
         Clone multiple activities.

--- a/pykechain/client.py
+++ b/pykechain/client.py
@@ -98,24 +98,24 @@ class Client(object):
         >>> client = Client(url='https://default-tst.localhost:9443', check_certificates=False)
 
         """
-        self.auth = None  # type: Optional[Tuple[str, str]]
-        self.headers = {'X-Requested-With': 'XMLHttpRequest',
-                        'PyKechain-Version': pykechain_version}  # type: Dict[str, str]
-        self.session = requests.Session()  # type: requests.Session
+        self.auth: Optional[Tuple[str, str]] = None
+        self.headers: Dict[str, str] = {'X-Requested-With': 'XMLHttpRequest',
+                        'PyKechain-Version': pykechain_version}
+        self.session: requests.Session = requests.Session()
 
         parsed_url = urlparse(url)
         if not (parsed_url.scheme and parsed_url.netloc):
             raise ClientError("Please provide a valid URL to a KE-chain instance")
 
         self.api_root = url
-        self.headers = {'X-Requested-With': 'XMLHttpRequest',
-                        'PyKechain-Version': pykechain_version}  # type: Dict[Text, Text]
-        self.auth = None  # type: Optional[Tuple[Text, Text]]
-        self.last_request = None  # type: Optional[requests.PreparedRequest]
-        self.last_response = None  # type: Optional[requests.Response]
-        self.last_url = None  # type: Optional[Text]
-        self._app_versions = None  # type: Optional[List[Dict]]
-        self._widget_schemas = None  # type: Optional[List[Dict]]
+        self.headers: Dict[Text, Text] = {'X-Requested-With': 'XMLHttpRequest',
+                        'PyKechain-Version': pykechain_version}
+        self.auth: Optional[Tuple[Text, Text]] = None
+        self.last_request: Optional[requests.PreparedRequest] = None
+        self.last_response: Optional[requests.Response] = None
+        self.last_url: Optional[Text] = None
+        self._app_versions: Optional[List[Dict]] = None
+        self._widget_schemas: Optional[List[Dict]] = None
 
         if check_certificates is None:
             check_certificates = env.bool(KechainEnv.KECHAIN_CHECK_CERTIFICATES, default=True)

--- a/pykechain/client_utils.py
+++ b/pykechain/client_utils.py
@@ -1,4 +1,4 @@
-from ssl import SSLCertVerificationError
+from ssl import SSLError
 
 from urllib3 import Retry
 from urllib3.exceptions import MaxRetryError
@@ -35,4 +35,4 @@ class PykeRetry(Retry):
 
     def _is_self_signed_certificate_error(self, error):
         error_msg = "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate"
-        return error and isinstance(error, SSLCertVerificationError) and error_msg in str(error)
+        return error and isinstance(error, SSLError) and error_msg in str(error)

--- a/pykechain/client_utils.py
+++ b/pykechain/client_utils.py
@@ -5,6 +5,12 @@ from urllib3.exceptions import MaxRetryError
 
 
 class PykeRetry(Retry):
+    """
+    Pykechain Implementation of urllib3.Retry function.
+
+    It contains a fast bailout of any SSLCertificate Errors.
+    """
+
     def increment(
         self,
         method=None,
@@ -14,9 +20,7 @@ class PykeRetry(Retry):
         _pool=None,
         _stacktrace=None,
     ):
-        """
-        In case of failed verification of self signed certificate we short circuit the retry routine.
-        """
+        """In case of failed verification of self signed certificate we short circuit the retry routine."""
         if self._is_self_signed_certificate_error(error):
             raise MaxRetryError(_pool, url, error)
 

--- a/pykechain/client_utils.py
+++ b/pykechain/client_utils.py
@@ -21,7 +21,7 @@ class PykeRetry(Retry):
         _stacktrace=None,
     ):
         """In case of failed verification of self signed certificate we short circuit the retry routine."""
-        if self._is_self_signed_certificate_error(error):
+        if self._is_ssl_error(error):
             raise MaxRetryError(_pool, url, error)
 
         return super().increment(
@@ -33,6 +33,5 @@ class PykeRetry(Retry):
             _stacktrace=_stacktrace,
         )
 
-    def _is_self_signed_certificate_error(self, error):
-        error_msg = "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate"
-        return error and isinstance(error, SSLError) and error_msg in str(error)
+    def _is_ssl_error(self, error):
+        return error and isinstance(error, SSLError)

--- a/pykechain/extra_utils.py
+++ b/pykechain/extra_utils.py
@@ -12,7 +12,7 @@ from pykechain.utils import temp_chdir
 
 # global variable
 __mapping_dictionary = None
-__edited_one_many = list()  # type: list
+__edited_one_many: list = list()
 __references = dict()
 __attachments = list()
 

--- a/pykechain/models/activity.py
+++ b/pykechain/models/activity.py
@@ -49,23 +49,23 @@ class Activity(TreeObject, TagsMixin):
 
         self._scope_id = json.get('scope_id')
 
-        self.ref = json.get('ref')  # type: Text
-        self.description = json.get('description', '')  # type: Text
-        self.status = json.get('status')  # type: ActivityStatus
-        self.classification = json.get('classification')  # type: ActivityClassification
-        self.activity_type = json.get('activity_type')  # type: ActivityType
+        self.ref: Text = json.get('ref')
+        self.description: Text = json.get('description', '')
+        self.status: ActivityStatus = json.get('status')
+        self.classification: ActivityClassification = json.get('classification')
+        self.activity_type: ActivityType = json.get('activity_type')
         self.start_date = parse_datetime(json.get('start_date'))
         self.due_date = parse_datetime(json.get('due_date'))
-        self.assignees_ids = json.get('assignees_ids', [])  # type: List[Text]
+        self.assignees_ids: List[Text] = json.get('assignees_ids', [])
         self._options = json.get('activity_options', {})
 
-        self._tags = json.get('tags', [])  # type: List[Text]
+        self._tags: List[Text] = json.get('tags', [])
         self._representations_container = RepresentationsComponent(
             self,
             self._options.get('representations', {}),
             self._save_representations,
         )
-        self._widgets_manager = None  # type: Optional[WidgetsManager]
+        self._widgets_manager: Optional[WidgetsManager] = None
 
     def __call__(self, *args, **kwargs) -> 'Activity':
         """Short-hand version of the `child` method."""

--- a/pykechain/models/base.py
+++ b/pykechain/models/base.py
@@ -19,7 +19,7 @@ class Base(object):
     def __init__(self, json: Dict, client: 'Client'):
         """Construct a model from provided json data."""
         self._json_data = json
-        self._client = client  # type: 'Client'
+        self._client: 'Client' = client
 
         self.id = json.get('id', None)
         self.name = json.get('name', None)
@@ -74,7 +74,7 @@ class BaseInScope(Base):
         super().__init__(json, *args, **kwargs)
 
         self.scope_id = json.get('scope_id', json.get('scope', None))
-        self._scope = None  # type: Optional['Scope']
+        self._scope: Optional['Scope'] = None
 
     @property
     def scope(self):

--- a/pykechain/models/base_reference.py
+++ b/pykechain/models/base_reference.py
@@ -16,7 +16,7 @@ class _ReferenceProperty(Property):
     :cvar REFERENCED_CLASS: handle to the Pykechain class that is referenced using this ReferenceProperty class.
     """
 
-    REFERENCED_CLASS = Base  # type: type(Base)
+    REFERENCED_CLASS: type(Base) = Base
 
     def __init__(self, json, **kwargs):
         """Construct a ReferenceProperty from a json object."""

--- a/pykechain/models/notification.py
+++ b/pykechain/models/notification.py
@@ -37,17 +37,17 @@ class Notification(Base):
         super().__init__(json, **kwargs)
 
         self.message = json.get('message', '')
-        self.subject = json.get('subject', '')  # type: Text
-        self.status = json.get('status', '')  # type: Text
-        self.event = json.get('event', '')  # type: Text
-        self.channels = json.get('channels', list())  # type: List
-        self.recipient_user_ids = json.get('recipient_users', list())  # type: List
-        self.team_id = json.get('team', '')  # type: Text
-        self.from_user_id = json.get('from_user', '')  # type: Text
+        self.subject: Text = json.get('subject', '')
+        self.status: Text = json.get('status', '')
+        self.event: Text = json.get('event', '')
+        self.channels: List = json.get('channels', list())
+        self.recipient_user_ids: List = json.get('recipient_users', list())
+        self.team_id: Text = json.get('team', '')
+        self.from_user_id: Text = json.get('from_user', '')
 
-        self._from_user = None  # type: Optional['User']
-        self._recipient_users = None  # type: Optional[List['User']]
-        self._team = None  # type: Optional['Team']
+        self._from_user: Optional['User'] = None
+        self._recipient_users: Optional[List['User']] = None
+        self._team: Optional['Team'] = None
 
     def __repr__(self):  # pragma: no cover
         return "<pyke Notification id {}>".format(self.id[-8:])

--- a/pykechain/models/part.py
+++ b/pykechain/models/part.py
@@ -78,18 +78,18 @@ class Part(TreeObject):
         # we need to run the init of 'Base' instead of 'Part' as we do not need the instantiation of properties
         super().__init__(json, **kwargs)
 
-        self.ref = json.get('ref')  # type: Text
-        self.model_id = json.get("model_id")  # type: Text
-        self.category = json.get('category')  # type: Category
-        self.description = json.get('description')  # type: Text
-        self.multiplicity = json.get('multiplicity')  # type: Text
-        self.classification = json.get('classification')  # type: Classification
+        self.ref: Text = json.get('ref')
+        self.model_id: Text = json.get("model_id")
+        self.category: Category = json.get('category')
+        self.description: Text = json.get('description')
+        self.multiplicity: Text = json.get('multiplicity')
+        self.classification: Classification = json.get('classification')
 
-        sorted_properties = sorted(json['properties'], key=lambda p: p.get('order', 0))  # type: List[Dict]
-        self.properties = [Property.create(p, client=self._client) for p in sorted_properties]  # type: List[Property]
+        sorted_properties: List[Dict] = sorted(json['properties'], key=lambda p: p.get('order', 0))
+        self.properties: List[Property] = [Property.create(p, client=self._client) for p in sorted_properties]
 
-        proxy_data = json.get('proxy_source_id_name', dict())  # type: Optional[Dict]
-        self._proxy_model_id = proxy_data.get('id') if proxy_data else None  # type: Optional[Text]
+        proxy_data: Optional[Dict] = json.get('proxy_source_id_name', dict())
+        self._proxy_model_id: Optional[Text] = proxy_data.get('id') if proxy_data else None
 
     def __call__(self, *args, **kwargs) -> 'Part':
         """Short-hand version of the `child` method."""
@@ -712,7 +712,7 @@ class Part(TreeObject):
         parsed_dict = dict()
 
         for prop_name_or_id, property_value in update_dict.items():
-            property_to_update = part.property(prop_name_or_id)  # type: Property
+            property_to_update: Property = part.property(prop_name_or_id)
 
             updated_p = {
                 "value": property_to_update.serialize_value(property_value),
@@ -810,7 +810,7 @@ class Part(TreeObject):
         if response.status_code != requests.codes.created:  # pragma: no cover
             raise APIError("Could not add to Part {}".format(self), response=response)
 
-        new_part_instance = Part(response.json()['results'][0], client=self._client)  # type: Part
+        new_part_instance: Part = Part(response.json()['results'][0], client=self._client)
 
         # ensure that cached children are updated
         if self._cached_children is not None:

--- a/pykechain/models/property.py
+++ b/pykechain/models/property.py
@@ -55,8 +55,8 @@ class Property(BaseInScope):
         """Construct a Property from a json object."""
         super().__init__(json, **kwargs)
 
-        self.output = json.get('output')  # type: bool
-        self.model_id = json.get('model_id')  # type: Optional[Text]
+        self.output: bool = json.get('output')
+        self.model_id: Optional[Text] = json.get('model_id')
         self.part_id = json.get('part_id')
         self.ref = json.get('ref')
         self.type = json.get('property_type')
@@ -66,13 +66,13 @@ class Property(BaseInScope):
         self.order = json.get('order')
 
         # Create protected variables
-        self._value = json.get('value')  # type: Any
-        self._options = json.get('value_options', {})  # type: Dict
-        self._part = None  # type: Optional['Part']
-        self._model = None  # type: Optional['Property']
-        self._validators = []  # type: List[PropertyValidator]
-        self._validation_results = []  # type: List
-        self._validation_reasons = []  # type: List
+        self._value: Any = json.get('value')
+        self._options: Dict = json.get('value_options', {})
+        self._part: Optional['Part'] = None
+        self._model: Optional['Property'] = None
+        self._validators: List[PropertyValidator] = []
+        self._validation_results: List = []
+        self._validation_reasons: List = []
 
         self._representations_container = RepresentationsComponent(
             self,

--- a/pykechain/models/property_multi_reference.py
+++ b/pykechain/models/property_multi_reference.py
@@ -74,8 +74,8 @@ class MultiReferenceProperty(_ReferencePropertyInScope):
             choices_model_id = self.model()._value[0].get('id')
 
             # Determine which parts are filtered out
-            prefilter = self._options.get(MetaWidget.PREFILTERS, {}). \
-                get(MetaWidget.PROPERTY_VALUE_PREFILTER)  # type: Optional[Text]
+            prefilter: Optional[Text] = self._options.get(MetaWidget.PREFILTERS, {}). \
+                get(MetaWidget.PROPERTY_VALUE_PREFILTER)
 
             # Retrieve all part instances with this model ID
             possible_choices = self._client.parts(

--- a/pykechain/models/representations/component.py
+++ b/pykechain/models/representations/component.py
@@ -29,10 +29,10 @@ class RepresentationsComponent(object):
         """
         self._parent_object = parent_object
         self._repr_options = representation_options
-        self._update_method = update_method  # type: Callable
+        self._update_method: Callable = update_method
 
         # Construct representation objects
-        self._representations = []  # type: List['AnyRepresentation']
+        self._representations: List['AnyRepresentation'] = []
         representations_json = self._repr_options
         for representation_json in representations_json:
             self._representations.append(

--- a/pykechain/models/representations/representation_base.py
+++ b/pykechain/models/representations/representation_base.py
@@ -43,9 +43,9 @@ class BaseRepresentation(object):
             del prop
 
         self._obj = obj
-        self._json = json or dict(rtype=self.rtype, config=dict())  # type: dict
+        self._json: dict = json or dict(rtype=self.rtype, config=dict())
 
-        self._config = self._json.get("config", dict())  # type: dict
+        self._config: dict = self._json.get("config", dict())
         self._json["config"] = self._config
 
         if value is not None:
@@ -85,7 +85,7 @@ class BaseRepresentation(object):
         try:
             from pykechain.models.representations import rtype_class_map
 
-            repr_class = rtype_class_map[rtype]  # type: type(BaseRepresentation)
+            repr_class: type(BaseRepresentation) = rtype_class_map[rtype]
         except KeyError:
             raise TypeError('Unknown rtype "{}" in json'.format(rtype))
 

--- a/pykechain/models/scope.py
+++ b/pykechain/models/scope.py
@@ -211,8 +211,8 @@ class Scope(Base, TagsMixin):
         role = check_enum(role, ScopeRoles, "role")
         user = check_text(user, "user")
 
-        users = self._client._retrieve_users()["results"]  # type: List[Dict]
-        user_object = find(users, lambda u: u["username"] == user)  # type: Dict
+        users: List[Dict] = self._client._retrieve_users()["results"]
+        user_object: Dict = find(users, lambda u: u["username"] == user)
         if user_object is None:
             raise NotFoundError('User "{}" does not exist'.format(user))
 

--- a/pykechain/models/service.py
+++ b/pykechain/models/service.py
@@ -54,10 +54,10 @@ class Service(BaseInScope):
         self.environment = json.get('env_version')
 
         # for SIM3 version
-        self.trusted = json.get('trusted')  # type: bool
-        self.run_as = json.get('run_as')  # type: Text
-        self.verified_on = parse_datetime(json.get('verified_on'))  # type: Optional[datetime]
-        self.verification_results = json.get('verification_results')  # type: Dict
+        self.trusted: bool = json.get('trusted')
+        self.run_as: Text = json.get('run_as')
+        self.verified_on: Optional[datetime] = parse_datetime(json.get('verified_on'))
+        self.verification_results: Dict = json.get('verification_results')
 
     def __repr__(self):  # pragma: no cover
         return "<pyke Service '{}' id {}>".format(self.name, self.id[-8:])
@@ -272,18 +272,18 @@ class ServiceExecution(Base):
 
         self.name = json.get('service_name')
         self.service_id = json.get('service')
-        self.status = json.get('status', '')  # type: ServiceExecutionStatus
+        self.status: ServiceExecutionStatus = json.get('status', '')
 
         self.user = json.get('username')
         if json.get('activity') is not None:
-            self.activity_id = json['activity'].get('id')  # type: Optional[Text]
+            self.activity_id: Optional[Text] = json['activity'].get('id')
         else:
             self.activity_id = None
 
-        self.started_at = parse_datetime(json.get('started_at'))  # type: Optional[datetime]
-        self.finished_at = parse_datetime(json.get('finished_at'))  # type: Optional[datetime]
+        self.started_at: Optional[datetime] = parse_datetime(json.get('started_at'))
+        self.finished_at: Optional[datetime] = parse_datetime(json.get('finished_at'))
 
-        self._service = None  # type: Optional[Service]
+        self._service: Optional[Service] = None
 
     def __repr__(self):  # pragma: no cover
         return "<pyke ServiceExecution '{}' id {}>".format(self.name, self.id[-8:])

--- a/pykechain/models/sidebar/sidebar_button.py
+++ b/pykechain/models/sidebar/sidebar_button.py
@@ -76,13 +76,13 @@ class SideBarButton(object):
                 raise IllegalArgumentError(
                     'Attribute "{}" is not supported in the configuration of a side-bar button.'.format(key))
 
-        self._manager = side_bar_manager  # type: 'SideBarManager'
-        self.display_name = title  # type: str
-        self.order = order  # type: int
-        self.display_icon = icon  # type: str
-        self.uri = uri  # type: str
-        self.uri_target = uri_target  # type: URITarget
-        self.display_icon_mode = icon_mode  # type: FontAwesomeMode
+        self._manager: 'SideBarManager' = side_bar_manager
+        self.display_name: str = title
+        self.order: int = order
+        self.display_icon: str = icon
+        self.uri: str = uri
+        self.uri_target: URITarget = uri_target
+        self.display_icon_mode: FontAwesomeMode = icon_mode
 
         self._other_attributes = kwargs
         for key in allowed_attributes:

--- a/pykechain/models/sidebar/sidebar_manager.py
+++ b/pykechain/models/sidebar/sidebar_manager.py
@@ -47,13 +47,13 @@ class SideBarManager(Iterable):
         from pykechain.models import Scope
         check_type(scope, Scope, 'scope')
 
-        self.scope = scope  # type: Scope
-        self._override = scope.options.get('overrideSideBar', False)  # type: bool
+        self.scope: Scope = scope
+        self._override: bool = scope.options.get('overrideSideBar', False)
 
         self._scope_uri = "#/scopes/{}".format(self.scope.id)
         self._perform_bulk_creation = False
 
-        self._buttons = []  # type: List[SideBarButton]
+        self._buttons: List[SideBarButton] = []
 
         # Load existing buttons from the scope
         for button_dict in scope.options.get('customNavigation', []):

--- a/pykechain/models/tags.py
+++ b/pykechain/models/tags.py
@@ -13,7 +13,7 @@ class TagsMixin:
     :type tags: list
     """
 
-    _tags = list()  # type: List[Text]
+    _tags: List[Text] = list()
 
     @abstractmethod
     def edit(self, tags: Optional[Iterable[Text]] = None, *args, **kwargs) -> None:

--- a/pykechain/models/tree_traversal.py
+++ b/pykechain/models/tree_traversal.py
@@ -20,9 +20,9 @@ class TreeObject(BaseInScope, ABC):
         """
         super().__init__(json=json, **kwargs)
 
-        self.parent_id = json.get('parent_id', None)  # type: Optional[Text]
-        self._parent = None  # type: Optional[T]
-        self._cached_children = None  # type: Optional[List[T]]
+        self.parent_id: Optional[Text] = json.get('parent_id', None)
+        self._parent: Optional[T] = None
+        self._cached_children: Optional[List[T]] = None
 
     def __call__(self: T, *args, **kwargs) -> T:
         """Short-hand version of the `child` method."""

--- a/pykechain/models/validators/effects.py
+++ b/pykechain/models/validators/effects.py
@@ -23,8 +23,7 @@ class TextEffect(ValidatorEffect):
         super(TextEffect, self).__init__(json=json, text=text, **kwargs)
         self.text = text
 
-    def as_json(self):
-        # type: () -> dict
+    def as_json(self) -> dict:
         """Represent effect as JSON dict."""
         self._config['text'] = self.text
         return self._json
@@ -95,8 +94,7 @@ class VisualEffect(ValidatorEffect):
         super(VisualEffect, self).__init__(json=json, **kwargs)
         self.applyCss = applyCss or self._config.get('applyCss')
 
-    def as_json(self):
-        # type: () -> dict
+    def as_json(self) -> dict:
         """Represent effect as JSON dict."""
         self._config['applyCss'] = self.applyCss
         self._json['config'] = self._config

--- a/pykechain/models/validators/validators.py
+++ b/pykechain/models/validators/validators.py
@@ -86,8 +86,7 @@ class NumericRangeValidator(PropertyValidator):
         if self.enforce_stepsize and self.stepsize is None:
             raise Exception('The stepsize should be provided when enforcing stepsize')
 
-    def _logic(self, value=None):
-        # type: (Any) -> Tuple[Union[bool, None], str]
+    def _logic(self, value: Any = None) -> Tuple[Union[bool, None], str]:
         basereason = "Value '{}' should be between {} and {}".format(value, self.minvalue, self.maxvalue)
         self._validation_result, self._validation_reason = None, "No reason"
 
@@ -137,8 +136,7 @@ class RequiredFieldValidator(PropertyValidator):
 
     vtype = PropertyVTypes.REQUIREDFIELD
 
-    def _logic(self, value=None):
-        # type: (Any) -> Tuple[Union[bool, None], str]
+    def _logic(self, value: Any = None) -> Tuple[Union[bool, None], str]:
         basereason = "Value is required"
         self._validation_result, self._validation_reason = None, "No reason"
 
@@ -181,8 +179,7 @@ class EvenNumberValidator(PropertyValidator):
 
     vtype = PropertyVTypes.EVENNUMBER
 
-    def _logic(self, value=None):
-        # type: (Any) -> Tuple[Union[bool, None], str]
+    def _logic(self, value: Any = None) -> Tuple[Union[bool, None], str]:
         if value is None:
             self._validation_result, self.validation_reason = None, "No reason"
             return self._validation_result, self._validation_reason
@@ -216,8 +213,7 @@ class OddNumberValidator(PropertyValidator):
 
     vtype = PropertyVTypes.ODDNUMBER
 
-    def _logic(self, value=None):
-        # type: (Any) -> Tuple[Union[bool, None], str]
+    def _logic(self, value: Any = None) -> Tuple[Union[bool, None], str]:
         if value is None:
             self._validation_result, self.validation_reason = None, "No reason"
             return self._validation_result, self._validation_reason
@@ -244,8 +240,7 @@ class SingleReferenceValidator(PropertyValidator):
 
     vtype = PropertyVTypes.SINGLEREFERENCE
 
-    def _logic(self, value=None):
-        # type: (Any) -> Tuple[Union[bool, None], str]
+    def _logic(self, value: Any = None) -> Tuple[Union[bool, None], str]:
         if value is None:
             self._validation_result, self.validation_reason = None, "No reason"
             return self._validation_result, self._validation_reason
@@ -313,8 +308,7 @@ class RegexStringValidator(PropertyValidator):
         self.pattern = self._config.get('pattern', r'.+')
         self._re = re.compile(self.pattern)
 
-    def _logic(self, value=None):
-        # type: (Any) -> Tuple[Union[bool, None], str]
+    def _logic(self, value: Any = None) -> Tuple[Union[bool, None], str]:
         if value is None:
             self._validation_result, self.validation_reason = None, "No reason"
             return self._validation_result, self._validation_reason
@@ -359,8 +353,7 @@ class AlwaysAllowValidator(PropertyValidator):
 
     vtype = PropertyVTypes.ALWAYSALLOW
 
-    def _logic(self, value=None):
-        # type: (Any) -> Tuple[Union[bool, None], str]
+    def _logic(self, value: Any = None) -> Tuple[Union[bool, None], str]:
         """Process the inner logic of the validator.
 
         The validation results are returned as tuple (boolean (true/false), reasontext)

--- a/pykechain/models/validators/validators_base.py
+++ b/pykechain/models/validators/validators_base.py
@@ -19,7 +19,7 @@ class BaseValidator(object):
     :type accuracy: float
     """
 
-    jsonschema = None  # type: Union[Dict, None]
+    jsonschema: Union[Dict, None] = None
     accuracy = 1E-6
 
     def __init__(self, json=None, *args, **kwargs):
@@ -54,7 +54,7 @@ class PropertyValidator(BaseValidator):
     :type jsonschema: dict
     """
 
-    vtype = PropertyVTypes.NONEVALIDATOR  # type: str
+    vtype: str = PropertyVTypes.NONEVALIDATOR
     jsonschema = validator_jsonschema_stub
 
     def __init__(self, json=None, *args, **kwargs):

--- a/pykechain/models/value_filter.py
+++ b/pykechain/models/value_filter.py
@@ -207,7 +207,7 @@ class ScopeFilter(BaseFilter):
         self.progress_lte = check_type(progress_lte, float, "progress_lte")
         self.tag = check_text(tag, "tag")
         self.team = check_base(team, Team, "team")
-        self.extra_filter = kwargs  # type: dict
+        self.extra_filter: dict = kwargs
 
     def __repr__(self):
         _repr = "ScopeFilter: "

--- a/pykechain/models/widgets/helpers.py
+++ b/pykechain/models/widgets/helpers.py
@@ -375,7 +375,7 @@ def _check_prefilters(part_model: 'Part', prefilters: Union[Dict, List]) -> List
     :raises IllegalArgumentError: when the type of the input is provided incorrect.
     """
     if isinstance(prefilters, dict):
-        property_models = prefilters.get(MetaWidget.PROPERTY_MODELS, [])  # type: List[Property, Text]  # noqa
+        property_models: List[Property, Text] = prefilters.get(MetaWidget.PROPERTY_MODELS, [])  # noqa
         values = prefilters.get(MetaWidget.VALUES, [])
         filters_type = prefilters.get(MetaWidget.FILTERS_TYPE, [])
 
@@ -423,7 +423,7 @@ def _check_excluded_propmodels(part_model: 'Part', property_models: List['AnyPro
     if not isinstance(part_model, Part):
         raise IllegalArgumentError('`part_model` must be a Part object, "{}" is not.'.format(part_model))
 
-    list_of_propmodels_excl = list()  # type: List['AnyProperty']
+    list_of_propmodels_excl: List['AnyProperty'] = list()
     for property_model in property_models:
         if is_uuid(property_model):
             property_model = part_model.property(property_model)

--- a/pykechain/models/widgets/widgets_manager.py
+++ b/pykechain/models/widgets/widgets_manager.py
@@ -24,15 +24,6 @@ from pykechain.enums import (
     ActivityType,
     ActivityClassification,
 )
-from pykechain.models.widgets.enums import (
-    DashboardWidgetSourceScopes,
-    DashboardWidgetShowTasks,
-    DashboardWidgetShowScopes,
-    MetaWidget,
-    AssociatedObjectId,
-    TasksAssignmentFilterTypes,
-    TasksWidgetColumns,
-)
 from pykechain.exceptions import NotFoundError, IllegalArgumentError
 from pykechain.models.input_checks import (
     check_enum,
@@ -43,6 +34,15 @@ from pykechain.models.input_checks import (
 )
 from pykechain.models.value_filter import PropertyValueFilter
 from pykechain.models.widgets import Widget
+from pykechain.models.widgets.enums import (
+    DashboardWidgetSourceScopes,
+    DashboardWidgetShowTasks,
+    DashboardWidgetShowScopes,
+    MetaWidget,
+    AssociatedObjectId,
+    TasksAssignmentFilterTypes,
+    TasksWidgetColumns,
+)
 from pykechain.models.widgets.helpers import (
     _set_title,
     _initiate_meta,
@@ -370,36 +370,36 @@ class WidgetsManager(Iterable):
         return widget
 
     def add_filteredgrid_widget(
-        self,
-        part_model: Union['Part', Text],
-        parent_instance: Optional[Union['Part', Text]] = None,
-        title: TITLE_TYPING = False,
-        parent_widget: Optional[Union[Widget, Text]] = None,
-        new_instance: Optional[bool] = True,
-        edit: Optional[bool] = True,
-        clone: Optional[bool] = True,
-        export: Optional[bool] = True,
-        upload: Optional[bool] = True,
-        delete: Optional[bool] = False,
-        incomplete_rows: Optional[bool] = True,
-        emphasize_new_instance: Optional[bool] = True,
-        emphasize_edit: Optional[bool] = False,
-        emphasize_clone: Optional[bool] = False,
-        emphasize_delete: Optional[bool] = False,
-        sort_property: Optional[Union['AnyProperty', Text]] = None,
-        sort_name: Optional[Union[bool, Text]] = False,
-        sort_direction: Optional[Union[SortTable, Text]] = SortTable.ASCENDING,
-        show_name_column: Optional[bool] = True,
-        show_images: Optional[bool] = False,
-        collapse_filters: Optional[bool] = False,
-        page_size: Optional[int] = 25,
-        readable_models: Optional[List[Union['AnyProperty', Text]]] = None,
-        writable_models: Optional[List[Union['AnyProperty', Text]]] = None,
-        all_readable: Optional[bool] = False,
-        all_writable: Optional[bool] = False,
-        excluded_propmodels: Optional[List[Union['AnyProperty', Text]]] = None,
-        prefilters: Optional[Union[List[PropertyValueFilter], Dict]] = None,
-        **kwargs
+            self,
+            part_model: Union['Part', Text],
+            parent_instance: Optional[Union['Part', Text]] = None,
+            title: TITLE_TYPING = False,
+            parent_widget: Optional[Union[Widget, Text]] = None,
+            new_instance: Optional[bool] = True,
+            edit: Optional[bool] = True,
+            clone: Optional[bool] = True,
+            export: Optional[bool] = True,
+            upload: Optional[bool] = True,
+            delete: Optional[bool] = False,
+            incomplete_rows: Optional[bool] = True,
+            emphasize_new_instance: Optional[bool] = True,
+            emphasize_edit: Optional[bool] = False,
+            emphasize_clone: Optional[bool] = False,
+            emphasize_delete: Optional[bool] = False,
+            sort_property: Optional[Union['AnyProperty', Text]] = None,
+            sort_name: Optional[Union[bool, Text]] = False,
+            sort_direction: Optional[Union[SortTable, Text]] = SortTable.ASCENDING,
+            show_name_column: Optional[bool] = True,
+            show_images: Optional[bool] = False,
+            collapse_filters: Optional[bool] = False,
+            page_size: Optional[int] = 25,
+            readable_models: Optional[List[Union['AnyProperty', Text]]] = None,
+            writable_models: Optional[List[Union['AnyProperty', Text]]] = None,
+            all_readable: Optional[bool] = False,
+            all_writable: Optional[bool] = False,
+            excluded_propmodels: Optional[List[Union['AnyProperty', Text]]] = None,
+            prefilters: Optional[Union[List[PropertyValueFilter], Dict]] = None,
+            **kwargs
     ) -> Widget:
         """
         Add a KE-chain superGrid (e.g. basic table widget) to the customization.
@@ -577,7 +577,7 @@ class WidgetsManager(Iterable):
         :raises APIError: When the widget could not be created.
         """
         attachment_property: 'Property' = _retrieve_object(attachment_property,
-                                               method=self._client.property)
+                                                           method=self._client.property)
         meta = _initiate_meta(kwargs, activity=self.activity)
 
         meta.update({
@@ -785,16 +785,16 @@ class WidgetsManager(Iterable):
         return widget
 
     def add_service_widget(
-        self,
-        service: 'Service',
-        title: TITLE_TYPING = False,
-        custom_button_text: TITLE_TYPING = False,
-        emphasize_run: Optional[bool] = True,
-        alignment: Optional[Alignment] = Alignment.LEFT,
-        download_log: Optional[bool] = False,
-        show_log: Optional[bool] = True,
-        parent_widget: Optional[Union[Widget, Text]] = None,
-        **kwargs
+            self,
+            service: 'Service',
+            title: TITLE_TYPING = False,
+            custom_button_text: TITLE_TYPING = False,
+            emphasize_run: Optional[bool] = True,
+            alignment: Optional[Alignment] = Alignment.LEFT,
+            download_log: Optional[bool] = False,
+            show_log: Optional[bool] = True,
+            parent_widget: Optional[Union[Widget, Text]] = None,
+            **kwargs
     ) -> Widget:
         """
         Add a KE-chain Service (e.g. script widget) to the widget manager.
@@ -1287,7 +1287,7 @@ class WidgetsManager(Iterable):
         :raises APIError: When the widget could not be created.
         """
         attachment_property: 'AttachmentProperty' = _retrieve_object(attachment_property,
-                                               method=self._client.property)  # noqa
+                                                                     method=self._client.property)  # noqa
         meta = _initiate_meta(kwargs, activity=self.activity)
         meta, title = _set_title(meta, title=title, **kwargs)
         check_type(editable, bool, "editable")
@@ -1426,20 +1426,20 @@ class WidgetsManager(Iterable):
         return widget
 
     def add_service_card_widget(
-        self,
-        service: 'Service',
-        image: Optional['AttachmentProperty'] = None,
-        title: TITLE_TYPING = False,
-        description: Optional[Union[Text]] = None,
-        parent_widget: Optional[Union[Widget, Text]] = None,
-        custom_button_text: TITLE_TYPING = False,
-        emphasize_run: Optional[bool] = True,
-        alignment: Optional[Alignment] = Alignment.LEFT,
-        link: Optional[Union[type(None), Text, bool, KEChainPages]] = None,
-        link_value: Optional[CardWidgetLinkValue] = None,
-        link_target: Optional[Union[Text, LinkTargets]] = LinkTargets.SAME_TAB,
-        image_fit: Optional[Union[ImageFitValue, Text]] = ImageFitValue.CONTAIN,
-        **kwargs
+            self,
+            service: 'Service',
+            image: Optional['AttachmentProperty'] = None,
+            title: TITLE_TYPING = False,
+            description: Optional[Union[Text]] = None,
+            parent_widget: Optional[Union[Widget, Text]] = None,
+            custom_button_text: TITLE_TYPING = False,
+            emphasize_run: Optional[bool] = True,
+            alignment: Optional[Alignment] = Alignment.LEFT,
+            link: Optional[Union[type(None), Text, bool, KEChainPages]] = None,
+            link_value: Optional[CardWidgetLinkValue] = None,
+            link_target: Optional[Union[Text, LinkTargets]] = LinkTargets.SAME_TAB,
+            image_fit: Optional[Union[ImageFitValue, Text]] = ImageFitValue.CONTAIN,
+            **kwargs
     ) -> Widget:
         """
         Add a KE-chain Service Card widget to the WidgetManager and the activity.
@@ -1510,22 +1510,22 @@ class WidgetsManager(Iterable):
         return widget
 
     def add_dashboard_widget(
-        self,
-        title: TITLE_TYPING = False,
-        parent_widget: Optional[Union[Widget, Text]] = None,
-        source_scopes: Optional[DashboardWidgetSourceScopes] = DashboardWidgetSourceScopes.CURRENT_SCOPE,
-        source_scopes_tags: Optional[List] = None,
-        source_subprocess: Optional[List] = None,
-        source_selected_scopes: Optional[List] = None,
-        show_tasks: Optional[List[DashboardWidgetShowTasks]] = None,
-        show_scopes: Optional[List[DashboardWidgetShowScopes]] = None,
-        no_background: Optional[bool] = False,
-        show_assignees: Optional[bool] = True,
-        show_assignees_table: Optional[bool] = True,
-        show_open_task_assignees: Optional[bool] = True,
-        show_open_vs_closed_tasks: Optional[bool] = True,
-        show_open_closed_tasks_assignees: Optional[bool] = True,
-        **kwargs
+            self,
+            title: TITLE_TYPING = False,
+            parent_widget: Optional[Union[Widget, Text]] = None,
+            source_scopes: Optional[DashboardWidgetSourceScopes] = DashboardWidgetSourceScopes.CURRENT_SCOPE,
+            source_scopes_tags: Optional[List] = None,
+            source_subprocess: Optional[List] = None,
+            source_selected_scopes: Optional[List] = None,
+            show_tasks: Optional[List[DashboardWidgetShowTasks]] = None,
+            show_scopes: Optional[List[DashboardWidgetShowScopes]] = None,
+            no_background: Optional[bool] = False,
+            show_assignees: Optional[bool] = True,
+            show_assignees_table: Optional[bool] = True,
+            show_open_task_assignees: Optional[bool] = True,
+            show_open_vs_closed_tasks: Optional[bool] = True,
+            show_open_closed_tasks_assignees: Optional[bool] = True,
+            **kwargs
     ) -> Widget:
         """
         Add a KE-chain Dashboard Widget to the WidgetManager and the activity.

--- a/pykechain/models/widgets/widgets_manager.py
+++ b/pykechain/models/widgets/widgets_manager.py
@@ -84,7 +84,7 @@ class WidgetsManager(Iterable):
         :returns: None
         :raises IllegalArgumentError: if not provided one of :class:`Activity` or activity uuid and a `Client`
         """
-        self._widgets = list(widgets)  # type: List[Widget]
+        self._widgets: List[Widget] = list(widgets)
         for widget in self._widgets:
             widget.manager = self
 
@@ -95,9 +95,9 @@ class WidgetsManager(Iterable):
             raise IllegalArgumentError(
                 "The `WidgetsManager` should be provided a :class:`Activity` to function properly.")
 
-        self.activity = activity  # type: Activity
+        self.activity: Activity = activity
         self._activity_id = activity.id
-        self._client = activity._client  # type: Client
+        self._client: Client = activity._client
 
     def __repr__(self) -> Text:  # pragma: no cover
         return "<pyke {} object {} widgets>".format(self.__class__.__name__, self.__len__())
@@ -323,8 +323,8 @@ class WidgetsManager(Iterable):
         :raises APIError: When the widget could not be created.
         """
         # Check whether the part_model is uuid type or class `Part`
-        part_model = _retrieve_object(obj=part_model, method=self._client.model)  # type: 'Part'  # noqa
-        parent_instance = _retrieve_object_id(obj=parent_instance)  # type: 'Part'  # noqa
+        part_model: 'Part' = _retrieve_object(obj=part_model, method=self._client.model)  # noqa
+        parent_instance: 'Part' = _retrieve_object_id(obj=parent_instance)  # noqa
         sort_property_id = _retrieve_object_id(obj=sort_property)
 
         meta = _initiate_meta(kwargs=kwargs, activity=self.activity)
@@ -479,9 +479,9 @@ class WidgetsManager(Iterable):
         :raises APIError: When the widget could not be created.
         """
         # Check whether the part_model is uuid type or class `Part`
-        part_model = _retrieve_object(obj=part_model, method=self._client.model)  # type: 'Part'  # noqa
-        parent_instance_id = _retrieve_object_id(obj=parent_instance)  # type: text_type
-        sort_property_id = _retrieve_object_id(obj=sort_property)  # type: text_type
+        part_model: 'Part' = _retrieve_object(obj=part_model, method=self._client.model)  # noqa
+        parent_instance_id: text_type = _retrieve_object_id(obj=parent_instance)
+        sort_property_id: text_type = _retrieve_object_id(obj=sort_property)
         if not sort_property_id and sort_name:
             sort_property_id = MetaWidget.NAME
         meta = _initiate_meta(kwargs=kwargs, activity=self.activity)
@@ -576,8 +576,8 @@ class WidgetsManager(Iterable):
         :raises IllegalArgumentError: when incorrect arguments are provided
         :raises APIError: When the widget could not be created.
         """
-        attachment_property = _retrieve_object(attachment_property,
-                                               method=self._client.property)  # type: 'Property'
+        attachment_property: 'Property' = _retrieve_object(attachment_property,
+                                               method=self._client.property)
         meta = _initiate_meta(kwargs, activity=self.activity)
 
         meta.update({
@@ -745,7 +745,7 @@ class WidgetsManager(Iterable):
         :raises APIError: When the widget could not be created.
         """
         # Check whether the part_model is uuid type or class `Part`
-        part_instance = _retrieve_object(part_instance, method=self._client.part)  # type: 'Part'  # noqa: F821
+        part_instance: 'Part' = _retrieve_object(part_instance, method=self._client.part)  # noqa: F821
 
         if not show_columns:
             show_columns = list()
@@ -830,7 +830,7 @@ class WidgetsManager(Iterable):
         :raises APIError: When the widget could not be created.
         """
         # Check whether the script is uuid type or class `Service`
-        service = _retrieve_object(obj=service, method=self._client.service)  # type: 'Service'  # noqa
+        service: 'Service' = _retrieve_object(obj=service, method=self._client.service)  # noqa
 
         meta = _initiate_meta(kwargs=kwargs, activity=self.activity)
         meta, title = _set_title(meta, title=title, **kwargs)
@@ -1286,8 +1286,8 @@ class WidgetsManager(Iterable):
         :raises IllegalArgumentError: when incorrect arguments are provided
         :raises APIError: When the widget could not be created.
         """
-        attachment_property = _retrieve_object(attachment_property,
-                                               method=self._client.property)  # type: 'AttachmentProperty'  # noqa
+        attachment_property: 'AttachmentProperty' = _retrieve_object(attachment_property,
+                                               method=self._client.property)  # noqa
         meta = _initiate_meta(kwargs, activity=self.activity)
         meta, title = _set_title(meta, title=title, **kwargs)
         check_type(editable, bool, "editable")
@@ -1407,7 +1407,7 @@ class WidgetsManager(Iterable):
         :raises IllegalArgumentError: when incorrect arguments are provided
         :raises APIError: When the widget could not be created.
         """
-        weather_property = _retrieve_object(weather_property, method=self._client.property)  # type: 'Property'  # noqa
+        weather_property: 'Property' = _retrieve_object(weather_property, method=self._client.property)  # noqa
         meta = _initiate_meta(kwargs, activity=self.activity)
         meta, title = _set_title(meta, title=title, **kwargs)
 
@@ -1482,7 +1482,7 @@ class WidgetsManager(Iterable):
         :return: Service Card Widget
         """
         # Check whether the script is uuid type or class `Service`
-        service = _retrieve_object(obj=service, method=self._client.service)  # type: 'Service'  # noqa
+        service: 'Service' = _retrieve_object(obj=service, method=self._client.service)  # noqa
 
         meta = _initiate_meta(kwargs=kwargs, activity=self.activity)
         meta, title = _set_title(meta, title=title, **kwargs)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,4 +1,5 @@
-from ssl import SSLCertVerificationError
+from ssl import SSLError
+
 from unittest import TestCase
 
 from pykechain.client_utils import PykeRetry
@@ -25,7 +26,7 @@ class TestPykeRetry(TestCase):
 
         with self.assertRaises(MaxRetryError):
             retry.increment(
-                error=SSLCertVerificationError(
+                error=SSLError(
                     "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate"
                 )
             )


### PR DESCRIPTION
Type annotations for python 3.6 and up instead of `# type:` comments.

- now includes variable annotations as well, next to function annotations.

Used the `com2ann` package from https://github.com/ilevkivskyi/com2ann


## Checklist:
- [x] My code follows the pykechain style
    - [x] I added type hinting to all functions
    - [x] I added documentation for all public functions
    - [x] I locally used `tox` to check for dists and docs errors
    - [x] My code passes the `pep8` and `flake8` linting checks and no warnings
    - [x] I removed unused imports, using `Code > Optimize Imports` in PyCharm
    - [x] I used [`black`](https://github.com/psf/black) to format the new code
- [x] I have added tests that prove my fix is effective or that my feature works
    - [x] I committed fresh test cassettes
    - [x] I have proper test coverage (don't decline the coverage of the test)
- [x] I asked another teammate to review the code
- [x] I update the Changelog.md with the appropriate changes.
