### PR TITLE
Update requirements.txt for coverage and coveralls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ semver==3.0.1
 pytest==7.4.0
 pytest-xdist[psutil]==3.3.1
 betamax==0.8.1
-coverage==7.2.7
+coverage~=6.5.0  # pinned to <7 as coveralls is preventing v7 for coverage
 pytest-cov==4.1.0
 coveralls==3.3.1
 


### PR DESCRIPTION
to fix documentation building problems

```
The conflict is caused by:
    The user requested coverage==7.2.7
    coveralls 3.3.1 depends on coverage!=6.0.*, !=6.1, !=6.1.1, <7.0 and >=4.1
```