### PR TITLE
Remove 'six' dependency from Pipfile, requirements-ci.txt, setup.py, …

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,6 @@ jsonschema = ">=3.0.0"
 semver = "*"
 typing = "*"
 pytz = "*"
-six = "*"
 pykechain = {editable = true, path = "."}
 pyOpenSSL = {version="*", markers="python_version <= '2.7'"}
 

--- a/pykechain/models/stored_file.py
+++ b/pykechain/models/stored_file.py
@@ -4,7 +4,7 @@ import os
 from typing import Any, List, Optional, Union
 
 import requests
-from six import BytesIO
+from io import BytesIO
 
 from pykechain.defaults import API_EXTRA_PARAMS
 from pykechain.enums import StoredFileCategory, StoredFileClassification, StoredFileSize

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -4,7 +4,6 @@
 requests>=2.20.0
 envparse
 typing
-six
 jsonschema
 semver==3.0.4
 pytz

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup(
         "requests>=2.20.0",
         "envparse",
         "typing",
-        "six",
         "jsonschema",
         "semver>=2.10.0",
         "pytz",

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ python =
 passenv = TRAVIS, TRAVIS_JOB_ID, TRAVIS_BRANCH
 deps =
     pytest
-    six
 
 commands =
     python setup.py test
@@ -38,7 +37,6 @@ basepython =
 passenv = TRAVIS, TRAVIS_JOB_ID, TRAVIS_BRANCH
 deps =
     pytest
-    six
     coverage
     coveralls
     typing


### PR DESCRIPTION
…and tox.ini; replace 'six.BytesIO' with 'io.BytesIO' in stored_file.py for improved compatibility.

Fixes #<issue>

## Checklist:
- [ ] My code follows the pykechain style
    - [ ] I added type hinting to all functions
    - [ ] I added documentation for all public functions
    - [ ] I locally used `tox` to check for dists and docs errors
    - [ ] My code passes the `pep8` and `flake8` linting checks and no warnings
    - [ ] I removed unused imports, using `Code > Optimize Imports` in PyCharm
    - [ ] I used [`black`](https://github.com/psf/black) to format the new code
- [ ] I have added tests that prove my fix is effective or that my feature works
    - [ ] I committed fresh test cassettes
    - [ ] I have proper test coverage (don't decline the coverage of the test)
- [ ] I asked another teammate to review the code
- [ ] I update the Changelog.md with the appropriate changes.
